### PR TITLE
Implement number of persons displayed in status bar

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -33,6 +33,7 @@ public class MainWindow extends UiPart<Stage> {
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
     private ResultDisplay resultDisplay;
+    private StatusBarFooter statusBarFooter;
     private HelpWindow helpWindow;
 
     @FXML
@@ -116,7 +117,8 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
+        statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
+        statusBarFooter.updateNumPersonsDisplayed(logic.getFilteredPersonList().size());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
@@ -177,6 +179,7 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+            statusBarFooter.updateNumPersonsDisplayed(logic.getFilteredPersonList().size());
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/address/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/address/ui/StatusBarFooter.java
@@ -16,6 +16,8 @@ public class StatusBarFooter extends UiPart<Region> {
 
     @FXML
     private Label saveLocationStatus;
+    @FXML
+    private Label numPersonsStatus;
 
     /**
      * Creates a {@code StatusBarFooter} with the given {@code Path}.
@@ -25,4 +27,7 @@ public class StatusBarFooter extends UiPart<Region> {
         saveLocationStatus.setText(Paths.get(".").resolve(saveLocation).toString());
     }
 
+    public void updateNumPersonsDisplayed(int numPersonsDisplayed) {
+        numPersonsStatus.setText(String.format("%d persons displayed.", numPersonsDisplayed));
+    }
 }

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -8,5 +8,6 @@
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10" />
   </columnConstraints>
-  <Label fx:id="saveLocationStatus" />
+  <Label fx:id="saveLocationStatus" alignment="CENTER_LEFT" textAlignment="LEFT" GridPane.columnIndex="0" />
+  <Label fx:id="numPersonsStatus" alignment="CENTER_RIGHT" textAlignment="RIGHT" GridPane.columnIndex="1" />
 </GridPane>


### PR DESCRIPTION
This PR fixes https://github.com/AY2122S1-CS2103-W14-2/tp/issues/74 by tweaking the status bar to have a right-aligned label containing the number of persons displayed. This number is updated when the window is initialised (under `MainWindow.fillInnerParts()`) and whenever a command is executed (under `MainWindow.executeCommand()`).