### PR TITLE
Update Edit Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -22,6 +22,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.ShnPeriod;
 
 /**
  * Edits the details of an existing person in the address book.
@@ -95,8 +96,32 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         CaseNumber updatedCaseNumber = editPersonDescriptor.getCaseNumber().orElse(personToEdit.getCaseNumber());
         Address updatedHomeAddress = editPersonDescriptor.getHomeAddress().orElse(personToEdit.getHomeAddress());
-
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedCaseNumber, updatedHomeAddress);
+        Optional<Address> workAddress = editPersonDescriptor.getWorkAddress();
+        if (workAddress.isEmpty()) {
+            workAddress = personToEdit.getWorkAddress();
+        }
+        Optional<Address> quarantineAddress = editPersonDescriptor.getQuarantineAddress();
+        if (quarantineAddress.isEmpty()) {
+            quarantineAddress = personToEdit.getQuarantineAddress();
+        }
+        Optional<ShnPeriod> shnPeriod = editPersonDescriptor.getShnPeriod();
+        if (shnPeriod.isEmpty()) {
+            shnPeriod = personToEdit.getShnPeriod();
+        }
+        Optional<Name> nextOfKinName = editPersonDescriptor.getNextOfKinName();
+        if (nextOfKinName.isEmpty()) {
+            nextOfKinName = personToEdit.getNextOfKinName();
+        }
+        Optional<Phone> nextOfKinPhone = editPersonDescriptor.getNextOfKinPhone();
+        if (nextOfKinPhone.isEmpty()) {
+            nextOfKinPhone = personToEdit.getNextOfKinPhone();
+        }
+        Optional<Address> nextOfKinAddress = editPersonDescriptor.getNextOfKinAddress();
+        if (nextOfKinAddress.isEmpty()) {
+            nextOfKinAddress = personToEdit.getNextOfKinAddress();
+        }
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedCaseNumber, updatedHomeAddress,
+                workAddress, quarantineAddress, shnPeriod, nextOfKinName, nextOfKinPhone, nextOfKinAddress);
     }
 
     @Override
@@ -127,6 +152,12 @@ public class EditCommand extends Command {
         private Email email;
         private CaseNumber caseNumber;
         private Address homeAddress;
+        private Address workAddress;
+        private Address quarantineAddress;
+        private ShnPeriod shnPeriod;
+        private Name nextOfKinName;
+        private Phone nextOfKinPhone;
+        private Address nextOfKinAddress;
 
         public EditPersonDescriptor() {}
 
@@ -139,13 +170,20 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setCaseNumber(toCopy.caseNumber);
             setHomeAddress(toCopy.homeAddress);
+            setWorkAddress(toCopy.workAddress);
+            setQuarantineAddress(toCopy.quarantineAddress);
+            setShnPeriod(toCopy.shnPeriod);
+            setNextOfKinName(toCopy.nextOfKinName);
+            setNextOfKinPhone(toCopy.nextOfKinPhone);
+            setNextOfKinAddress(toCopy.nextOfKinAddress);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, caseNumber, homeAddress);
+            return CollectionUtil.isAnyNonNull(name, phone, email, caseNumber, homeAddress,
+                    workAddress, quarantineAddress, shnPeriod, nextOfKinName, nextOfKinPhone, nextOfKinAddress);
         }
 
         public void setName(Name name) {
@@ -188,6 +226,54 @@ public class EditCommand extends Command {
             return Optional.ofNullable(homeAddress);
         }
 
+        public void setWorkAddress(Address workAddress) {
+            this.workAddress = workAddress;
+        }
+
+        public Optional<Address> getWorkAddress() {
+            return Optional.ofNullable(workAddress);
+        }
+
+        public void setQuarantineAddress(Address quarantineAddress) {
+            this.quarantineAddress = quarantineAddress;
+        }
+
+        public Optional<Address> getQuarantineAddress() {
+            return Optional.ofNullable(quarantineAddress);
+        }
+
+        public void setShnPeriod(ShnPeriod shnPeriod) {
+            this.shnPeriod = shnPeriod;
+        }
+
+        public Optional<ShnPeriod> getShnPeriod() {
+            return Optional.ofNullable(shnPeriod);
+        }
+
+        public void setNextOfKinName(Name nextOfKinName) {
+            this.nextOfKinName = nextOfKinName;
+        }
+
+        public Optional<Name> getNextOfKinName() {
+            return Optional.ofNullable(nextOfKinName);
+        }
+
+        public void setNextOfKinPhone(Phone nextOfKinPhone) {
+            this.nextOfKinPhone = nextOfKinPhone;
+        }
+
+        public Optional<Phone> getNextOfKinPhone() {
+            return Optional.ofNullable(nextOfKinPhone);
+        }
+
+        public void setNextOfKinAddress(Address nextOfKinAddress) {
+            this.nextOfKinAddress = nextOfKinAddress;
+        }
+
+        public Optional<Address> getNextOfKinAddress() {
+            return Optional.ofNullable(nextOfKinAddress);
+        }
+
         @Override
         public boolean equals(Object other) {
             // short circuit if same object
@@ -207,7 +293,13 @@ public class EditCommand extends Command {
                     && getPhone().equals(e.getPhone())
                     && getEmail().equals(e.getEmail())
                     && getCaseNumber().equals(e.getCaseNumber())
-                    && getHomeAddress().equals(e.getHomeAddress());
+                    && getHomeAddress().equals(e.getHomeAddress())
+                    && getWorkAddress().equals(e.getWorkAddress())
+                    && getQuarantineAddress().equals(e.getQuarantineAddress())
+                    && getShnPeriod().equals(e.getShnPeriod())
+                    && getNextOfKinName().equals(e.getNextOfKinName())
+                    && getNextOfKinPhone().equals(e.getNextOfKinPhone())
+                    && getNextOfKinAddress().equals(e.getNextOfKinAddress());
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -6,7 +6,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CASE_NUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOME_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_QUARANTINE_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SHN_PERIOD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_WORK_ADDRESS;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
@@ -26,7 +32,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_CASE_NUMBER, PREFIX_HOME_ADDRESS);
+                PREFIX_CASE_NUMBER, PREFIX_HOME_ADDRESS, PREFIX_WORK_ADDRESS, PREFIX_QUARANTINE_ADDRESS,
+                PREFIX_SHN_PERIOD, PREFIX_NEXT_OF_KIN_NAME, PREFIX_NEXT_OF_KIN_PHONE, PREFIX_NEXT_OF_KIN_ADDRESS);
 
         Index index;
 
@@ -53,6 +60,30 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_HOME_ADDRESS).isPresent()) {
             editPersonDescriptor.setHomeAddress(ParserUtil.parseAddress(
                     argMultimap.getValue(PREFIX_HOME_ADDRESS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_WORK_ADDRESS).isPresent()) {
+            editPersonDescriptor.setWorkAddress(ParserUtil.parseAddress(
+                    argMultimap.getValue(PREFIX_WORK_ADDRESS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_QUARANTINE_ADDRESS).isPresent()) {
+            editPersonDescriptor.setQuarantineAddress(ParserUtil.parseAddress(
+                    argMultimap.getValue(PREFIX_QUARANTINE_ADDRESS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_SHN_PERIOD).isPresent()) {
+            editPersonDescriptor.setShnPeriod(ParserUtil.parseShnPeriod(
+                    argMultimap.getValue(PREFIX_SHN_PERIOD).get()));
+        }
+        if (argMultimap.getValue(PREFIX_NEXT_OF_KIN_NAME).isPresent()) {
+            editPersonDescriptor.setNextOfKinName(ParserUtil.parseName(
+                    argMultimap.getValue(PREFIX_NEXT_OF_KIN_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_NEXT_OF_KIN_PHONE).isPresent()) {
+            editPersonDescriptor.setNextOfKinPhone(ParserUtil.parsePhone(
+                    argMultimap.getValue(PREFIX_NEXT_OF_KIN_PHONE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_NEXT_OF_KIN_ADDRESS).isPresent()) {
+            editPersonDescriptor.setNextOfKinAddress(ParserUtil.parseAddress(
+                    argMultimap.getValue(PREFIX_NEXT_OF_KIN_ADDRESS).get()));
         }
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {


### PR DESCRIPTION
Update edit command to work with optional fields in person class. Merging this PR fixes issue #77. 

Newly added optional fields from v1.2 includes a contacts', `workAddress`, `quarantineAddress`, `shnPeriod`, `nextOfKinName`, `nextOfKinPhone` and `nextOfKinAddress`.