### PR TITLE
Find command: Allow FindCommand to search by Phone, Case Number, SHN Period (start date) and SHN Period (end date)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,27 +1,44 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CASE_NUMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SHN_PERIOD_END;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SHN_PERIOD_START;
+
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Finds and lists all persons in address book who fulfills the criteria specified by the
+ * user. Only one parameter can be specified at a time, but multiple arguments can be specified.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons who fulfills the "
+            + "criteria specified by the user. " + "User should specify only one parameter from the "
+            + "following: "
+            + "1. Name: \"" + PREFIX_NAME + "\" KEYWORD [MORE_KEYWORDS] "
+            + "2. Phone: \"" + PREFIX_PHONE + "\" KEY_NUMBERS [MORE_KEY_NUMBERS] "
+            + "3. Case Number: \"" + PREFIX_CASE_NUMBER + "\" KEY_NUMBERS [MORE_KEY_NUMBERS] "
+            + "4. Shn Period (start): \"" + PREFIX_SHN_PERIOD_START + "\" KEY_DATE [MORE_KEY_DATES] "
+            + "5. Shn Period (end): \"" + PREFIX_SHN_PERIOD_END + "\" KEY_DATE [MORE_KEY_DATES] \n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<Person> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    /**
+     * Creates a FindCommand to search by the specified {@code Predicate}
+     */
+    public FindCommand(Predicate<Person> predicate) {
+        requireNonNull(predicate);
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -15,7 +15,9 @@ import java.util.Optional;
  */
 public class ArgumentMultimap {
 
-    /** Prefixes mapped to their respective arguments**/
+    /**
+     * Prefixes mapped to their respective arguments
+     **/
     private final Map<Prefix, List<String>> argMultimap = new HashMap<>();
 
     /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -17,4 +17,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_NEXT_OF_KIN_NAME = new Prefix("kn/");
     public static final Prefix PREFIX_NEXT_OF_KIN_PHONE = new Prefix("kp/");
     public static final Prefix PREFIX_NEXT_OF_KIN_ADDRESS = new Prefix("ka/");
+    public static final Prefix PREFIX_SHN_PERIOD_START = new Prefix("sh/start:");
+    public static final Prefix PREFIX_SHN_PERIOD_END = new Prefix("sh/end:");
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,24 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CASE_NUMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SHN_PERIOD_END;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SHN_PERIOD_START;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.CaseNumberContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.ShnPeriodEndContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.ShnPeriodStartContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +31,59 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
+                PREFIX_CASE_NUMBER, PREFIX_SHN_PERIOD_START, PREFIX_SHN_PERIOD_END);
+
+        List<Prefix> prefixesWithValue = getPrefixesWithValue(argMultimap, PREFIX_NAME,
+                PREFIX_PHONE, PREFIX_CASE_NUMBER, PREFIX_SHN_PERIOD_START, PREFIX_SHN_PERIOD_END);
+
+        // Checks if exactly one prefix is entered by the user
+        if (prefixesWithValue.size() != 1 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        Prefix prefixWithValue = prefixesWithValue.get(0);
+        String value = argMultimap.getValue(prefixWithValue).get().trim();
+        // Checks if user entered an argument along with the prefix
+        if (value.isBlank()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        String[] keywords = value.split("\\s+");
+        List<String> keywordList = Arrays.asList(keywords);
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            return new FindCommand(new NameContainsKeywordsPredicate(keywordList));
+        }
+
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            return new FindCommand(new PhoneContainsKeywordsPredicate(keywordList));
+        }
+
+        if (argMultimap.getValue(PREFIX_CASE_NUMBER).isPresent()) {
+            return new FindCommand(new CaseNumberContainsKeywordsPredicate(keywordList));
+        }
+
+        if (argMultimap.getValue(PREFIX_SHN_PERIOD_START).isPresent()) {
+            return new FindCommand(new ShnPeriodStartContainsKeywordsPredicate(keywordList));
+        }
+
+        if (argMultimap.getValue(PREFIX_SHN_PERIOD_END).isPresent()) {
+            return new FindCommand(new ShnPeriodEndContainsKeywordsPredicate(keywordList));
+        }
+
+        throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
+    /**
+     * Returns a list of prefixes with non-empty arguments.
+     */
+    private List<Prefix> getPrefixesWithValue(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        List<Prefix> prefixesWithNonEmptyArguments = Stream.of(prefixes)
+                .filter(prefix -> argumentMultimap.getValue(prefix).isPresent())
+                .collect(Collectors.toList());
+        return prefixesWithNonEmptyArguments;
+    }
 }

--- a/src/main/java/seedu/address/model/person/predicates/CaseNumberContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/CaseNumberContainsKeywordsPredicate.java
@@ -1,0 +1,27 @@
+package seedu.address.model.person.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.model.person.Person;
+
+public class CaseNumberContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public CaseNumberContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> person.getCaseNumber().value.contains(String.valueOf(keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CaseNumberContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((CaseNumberContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
@@ -1,9 +1,10 @@
-package seedu.address.model.person;
+package seedu.address.model.person.predicates;
 
 import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
+import seedu.address.model.person.Person;
 
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
@@ -27,5 +28,4 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
                 || (other instanceof NameContainsKeywordsPredicate // instanceof handles nulls
                 && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
     }
-
 }

--- a/src/main/java/seedu/address/model/person/predicates/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/PhoneContainsKeywordsPredicate.java
@@ -1,0 +1,27 @@
+package seedu.address.model.person.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.model.person.Person;
+
+public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public PhoneContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(key -> person.getPhone().value.contains(String.valueOf(key)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PhoneContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((PhoneContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/person/predicates/ShnPeriodEndContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/ShnPeriodEndContainsKeywordsPredicate.java
@@ -1,0 +1,28 @@
+package seedu.address.model.person.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.model.person.Person;
+
+public class ShnPeriodEndContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public ShnPeriodEndContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> person.getShnPeriod()
+                .map(sh -> sh.endDate.toString().contains(keyword)).orElse(false));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ShnPeriodEndContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((ShnPeriodEndContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/person/predicates/ShnPeriodStartContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/ShnPeriodStartContainsKeywordsPredicate.java
@@ -1,0 +1,28 @@
+package seedu.address.model.person.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.model.person.Person;
+
+public class ShnPeriodStartContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public ShnPeriodStartContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> person.getShnPeriod()
+                .map(sh -> sh.startDate.toString().contains(keyword)).orElse(false));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ShnPeriodStartContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((ShnPeriodStartContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -23,8 +23,8 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 /**

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -57,7 +57,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -67,7 +67,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -77,7 +77,7 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
+    private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
         return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -29,8 +29,8 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.TShiftCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -79,8 +79,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        FindCommand command = (FindCommand) parser.parseCommand(FindCommand.COMMAND_WORD + " "
+               + PREFIX_NAME + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,11 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CASE_NUMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SHN_PERIOD_END;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SHN_PERIOD_START;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -9,7 +14,12 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.predicates.CaseNumberContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.ShnPeriodEndContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.ShnPeriodStartContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -17,18 +27,102 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        // No prefix
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // Name prefix with blank argument
+        assertParseFailure(parser, " " + PREFIX_NAME + "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // Phone prefix with blank argument
+        assertParseFailure(parser, " " + PREFIX_PHONE + "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // Case number prefix with blank argument
+        assertParseFailure(parser, " " + PREFIX_CASE_NUMBER + "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // Shn period (start) prefix with blank argument
+        assertParseFailure(parser, " " + PREFIX_SHN_PERIOD_START + "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // Shn period (end) prefix with blank argument
+        assertParseFailure(parser, " " + PREFIX_SHN_PERIOD_END + "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
+    public void parse_validNameArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces after prefix
         FindCommand expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        String testInput = " " + PREFIX_NAME + "Alice Bob";
+        assertParseSuccess(parser, testInput, expectedFindCommand);
 
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        // multiple whitespaces between keywords after prefix
+        String testInputWithWhiteSpaces = " " + PREFIX_NAME + " \n Alice \n \t Bob  \t";
+        assertParseSuccess(parser, testInputWithWhiteSpaces, expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validPhoneArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces after prefix
+        FindCommand expectedFindCommand =
+                new FindCommand(new PhoneContainsKeywordsPredicate(Arrays.asList("111", "222")));
+
+        String testInput = " " + PREFIX_PHONE + "111 222";
+        assertParseSuccess(parser, testInput, expectedFindCommand);
+
+        // multiple whitespaces between keywords after prefix
+        String testInputWithWhiteSpaces = " " + PREFIX_PHONE + " \n 111 \n \t 222  \t";
+        assertParseSuccess(parser, testInputWithWhiteSpaces, expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validCaseNumberArgs_returnsFindCommand() throws ParseException {
+        // no leading and trailing whitespaces after prefix
+        FindCommand expectedFindCommand =
+                new FindCommand(new CaseNumberContainsKeywordsPredicate(Arrays.asList("111", "222")));
+
+        String testInput = " " + PREFIX_CASE_NUMBER + "111 222";
+        assertParseSuccess(parser, testInput, expectedFindCommand);
+
+        // multiple whitespaces between keywords after prefix
+        String testInputWithWhiteSpaces = " " + PREFIX_CASE_NUMBER + " \n 111 \n \t 222  \t";
+        assertParseSuccess(parser, testInputWithWhiteSpaces, expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validShnPeriodStartArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces after prefix
+        FindCommand expectedFindCommand =
+                new FindCommand(new ShnPeriodStartContainsKeywordsPredicate(Arrays.asList("2000-01-01",
+                        "2000-01-10")));
+
+        String testInput = " " + PREFIX_SHN_PERIOD_START + "2000-01-01 2000-01-10";
+        assertParseSuccess(parser, testInput, expectedFindCommand);
+
+        // multiple whitespaces between keywords after prefix
+        String testInputWithWhiteSpaces = " " + PREFIX_SHN_PERIOD_START
+                + " \n 2000-01-01 \n \t 2000-01-10  \t";
+        assertParseSuccess(parser, testInputWithWhiteSpaces, expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validShnPeriodEndArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces after prefix
+        FindCommand expectedFindCommand =
+                new FindCommand(new ShnPeriodEndContainsKeywordsPredicate(Arrays.asList("2000-01-01",
+                        "2000-01-10")));
+
+        String testInput = " " + PREFIX_SHN_PERIOD_END + "2000-01-01 2000-01-10";
+        assertParseSuccess(parser, testInput, expectedFindCommand);
+
+        // multiple whitespaces between keywords after prefix
+        String testInputWithWhiteSpaces = " " + PREFIX_SHN_PERIOD_END
+                + " \n 2000-01-01 \n \t 2000-01-10  \t";
+        assertParseSuccess(parser, testInputWithWhiteSpaces, expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {

--- a/src/test/java/seedu/address/model/person/predicates/CaseNumberContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/CaseNumberContainsKeywordsPredicateTest.java
@@ -1,0 +1,79 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class CaseNumberContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("1");
+        List<String> secondPredicateKeywordList = Arrays.asList("1", "2");
+
+        CaseNumberContainsKeywordsPredicate firstPredicate =
+                new CaseNumberContainsKeywordsPredicate(firstPredicateKeywordList);
+        CaseNumberContainsKeywordsPredicate secondPredicate =
+                new CaseNumberContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        CaseNumberContainsKeywordsPredicate firstPredicateCopy =
+                new CaseNumberContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_caseNumberContainsKeywords_returnsTrue() {
+        // One keyword
+        CaseNumberContainsKeywordsPredicate predicate =
+                new CaseNumberContainsKeywordsPredicate(Collections.singletonList("601"));
+        assertTrue(predicate.test(new PersonBuilder().withCaseNumber("60110").build()));
+
+        // Multiple keyword
+        predicate = new CaseNumberContainsKeywordsPredicate(Arrays.asList("601", "110"));
+        assertTrue(predicate.test(new PersonBuilder().withCaseNumber("60110").build()));
+
+        // Only one matching keyword
+        predicate = new CaseNumberContainsKeywordsPredicate(Arrays.asList("110", "111"));
+        assertTrue(predicate.test(new PersonBuilder().withCaseNumber("601110").build()));
+    }
+
+    @Test
+    public void test_caseNumberDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        CaseNumberContainsKeywordsPredicate predicate =
+                new CaseNumberContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withCaseNumber("601110").build()));
+
+        // Non-matching keyword
+        predicate = new CaseNumberContainsKeywordsPredicate(Arrays.asList("666"));
+        assertFalse(predicate.test(new PersonBuilder().withCaseNumber("601110").build()));
+
+        // Keywords match name, phone, email, address, shn period (start) and shn period (end), but does not match
+        // case number
+        predicate = new CaseNumberContainsKeywordsPredicate(Arrays.asList("Alice", "12345", "alice@email.com", "Main",
+                "Street", "2000-01-01", "01-02"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345").withEmail("alice@email.com")
+                .withCaseNumber("601110").withHomeAddress("Main Street").withShnPeriod("2000-01-01 => 2000-01-02")
+                .build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicateTest.java
@@ -1,4 +1,4 @@
-package seedu.address.model.person;
+package seedu.address.model.person.predicates;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -67,9 +67,11 @@ public class NameContainsKeywordsPredicateTest {
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
-        // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withHomeAddress("Main Street").build()));
+        // Keywords match phone, email, case number, address, shn period (start) and shn period (end), but not name
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "601110", "Main",
+                "Street", "2000-01-01", "01-02"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345").withEmail("alice@email.com")
+                .withCaseNumber("601110").withHomeAddress("Main Street").withShnPeriod("2000-01-01 => 2000-01-02")
+                .build()));
     }
 }

--- a/src/test/java/seedu/address/model/person/predicates/PhoneContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/PhoneContainsKeywordsPredicateTest.java
@@ -1,0 +1,76 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class PhoneContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("11111111");
+        List<String> secondPredicateKeywordList = Arrays.asList("11111111", "22222222");
+
+        PhoneContainsKeywordsPredicate firstPredicate = new PhoneContainsKeywordsPredicate(firstPredicateKeywordList);
+        PhoneContainsKeywordsPredicate secondPredicate = new PhoneContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        PhoneContainsKeywordsPredicate firstPredicateCopy =
+                new PhoneContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_phoneContainsKeywords_returnsTrue() {
+        // One keyword
+        PhoneContainsKeywordsPredicate predicate =
+                new PhoneContainsKeywordsPredicate(Collections.singletonList("1234"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Multiple keywords
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("123", "234"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Only one matching keyword
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("123", "666"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+    }
+
+    @Test
+    public void test_phoneDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Non-matching keyword
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("666"));
+        assertFalse(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // keywords match name, email, case number, address, shn period (start) and shn period (end), but does not match
+        // phone
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("Alice", "alice@email.com", "601110", "Main",
+                "Street", "2000-01-01", "01-02"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345").withEmail("alice@email.com")
+                .withCaseNumber("601110").withHomeAddress("Main Street").withShnPeriod("2000-01-01 => 2000-01-02")
+                .build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/ShnPeriodEndContainsKeywordsPredicatesTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/ShnPeriodEndContainsKeywordsPredicatesTest.java
@@ -1,0 +1,82 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class ShnPeriodEndContainsKeywordsPredicatesTest {
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("2000-01-01");
+        List<String> secondPredicateKeywordList = Arrays.asList("2000-01-01", "2000-01-02");
+
+        ShnPeriodEndContainsKeywordsPredicate firstPredicate =
+                new ShnPeriodEndContainsKeywordsPredicate(firstPredicateKeywordList);
+        ShnPeriodEndContainsKeywordsPredicate secondPredicate =
+                new ShnPeriodEndContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        ShnPeriodEndContainsKeywordsPredicate firstPredicateCopy =
+                new ShnPeriodEndContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_shnPeriodEndContainsKeywords_returnsTrue() {
+        // One keyword
+        ShnPeriodEndContainsKeywordsPredicate predicate =
+                new ShnPeriodEndContainsKeywordsPredicate(Collections.singletonList("01-02"));
+        assertTrue(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+
+        // Multiple keywords
+        predicate = new ShnPeriodEndContainsKeywordsPredicate(Arrays.asList("2000", "01-02"));
+        assertTrue(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+
+        // Only one matching keyword
+        predicate = new ShnPeriodEndContainsKeywordsPredicate(Arrays.asList("1999", "01-02"));
+        assertTrue(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+    }
+
+    @Test
+    public void test_shnPeriodEndDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        ShnPeriodEndContainsKeywordsPredicate predicate =
+                new ShnPeriodEndContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+
+        // Non-matching keyword
+        predicate = new ShnPeriodEndContainsKeywordsPredicate(Arrays.asList("1999"));
+        assertFalse(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+
+        // Keyword matches with shn period start
+        predicate = new ShnPeriodEndContainsKeywordsPredicate(Arrays.asList("2000-01-01"));
+        assertFalse(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+
+        // Keywords match name, phone, email, case number,  address, shn period (start), but does not match
+        // shn period (end)
+        predicate = new ShnPeriodEndContainsKeywordsPredicate(Arrays.asList("Alice", "12345", "alice@email.com",
+                "601110", "Main", "Street", "2000-01-01"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345").withEmail("alice@email.com")
+                .withCaseNumber("601110").withHomeAddress("Main Street").withShnPeriod("2000-01-01 => 2000-01-02")
+                .build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/ShnPeriodStartContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/ShnPeriodStartContainsKeywordsPredicateTest.java
@@ -1,0 +1,82 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class ShnPeriodStartContainsKeywordsPredicateTest {
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("2000-01-01");
+        List<String> secondPredicateKeywordList = Arrays.asList("2000-01-01", "2000-01-02");
+
+        ShnPeriodStartContainsKeywordsPredicate firstPredicate =
+                new ShnPeriodStartContainsKeywordsPredicate(firstPredicateKeywordList);
+        ShnPeriodStartContainsKeywordsPredicate secondPredicate =
+                new ShnPeriodStartContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        ShnPeriodStartContainsKeywordsPredicate firstPredicateCopy =
+                new ShnPeriodStartContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_shnPeriodStartContainsKeywords_returnsTrue() {
+        // One keyword
+        ShnPeriodStartContainsKeywordsPredicate predicate =
+                new ShnPeriodStartContainsKeywordsPredicate(Collections.singletonList("01-01"));
+        assertTrue(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+
+        // Multiple keywords
+        predicate = new ShnPeriodStartContainsKeywordsPredicate(Arrays.asList("2000", "01-01"));
+        assertTrue(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+
+        // Only one matching keyword
+        predicate = new ShnPeriodStartContainsKeywordsPredicate(Arrays.asList("1999", "01-01"));
+        assertTrue(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+    }
+
+    @Test
+    public void test_shnPeriodStartDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        ShnPeriodStartContainsKeywordsPredicate predicate =
+                new ShnPeriodStartContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+
+        // Non-matching keyword
+        predicate = new ShnPeriodStartContainsKeywordsPredicate(Arrays.asList("1999"));
+        assertFalse(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+
+        // Keyword matches with shn period end
+        predicate = new ShnPeriodStartContainsKeywordsPredicate(Arrays.asList("2000-01-02"));
+        assertFalse(predicate.test(new PersonBuilder().withShnPeriod("2000-01-01 => 2000-01-02").build()));
+
+        // Keywords match name, phone, email, case number,  address, shn period (end), but does not match
+        // shn period (start)
+        predicate = new ShnPeriodStartContainsKeywordsPredicate(Arrays.asList("Alice", "12345", "alice@email.com",
+                "601110", "Main", "Street", "2000-01-02"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345").withEmail("alice@email.com")
+                .withCaseNumber("601110").withHomeAddress("Main Street").withShnPeriod("2000-01-01 => 2000-01-02")
+                .build()));
+    }
+}


### PR DESCRIPTION
Command word: `find`

Prefixes: `n/`, `p/`, `cn/`, `sh/start:`, `sh/end:`

FindCommand finds by Name.

Changing it to allow find by Phone, Case Number, SHN Period (start date) and SHN Period (end date) will allow for a more flexible search of contacts.

Let's
- Change FindCommand to find by Phone, Case Number, SHN Period (start date) and SHN Period (end date).
- Implement FindCommand to search by **only one category** at a time.
- Allow FindCommand to take in multiple arguments for a category.
