### PR TITLE
Implement TShiftCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -100,7 +100,7 @@ public class EditCommand extends Command {
      * Creates and returns a {@code Person} with the details of {@code personToEdit}
      * edited with {@code editPersonDescriptor}.
      */
-    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
+    public static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
         assert personToEdit != null;
 
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());

--- a/src/main/java/seedu/address/logic/commands/TShiftCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TShiftCommand.java
@@ -1,0 +1,85 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.ShnPeriod;
+
+public class TShiftCommand extends Command {
+
+    public static final String COMMAND_WORD = "tshift";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shifts all persons' SHN end date "
+            + "by the specified number of DAYS.\n"
+            + "Parameters: [PLUS_MINUS_SIGN]DAYS\n"
+            + "Example: " + COMMAND_WORD + " 3";
+
+    public static final String MESSAGE_SUCCESS = "All SHN end dates have been shifted accordingly.";
+    public static final String MESSAGE_TSHIFT_BY_ZERO = "Number of days to shift the SHN end dates by should not be 0.";
+    public static final String MESSAGE_BEYOND_LIMIT = "Magnitude of shift should not be larger than %d days.";
+    public static final int MAX_ABS_DAYS_VALUE = 90;
+
+    private final int days;
+
+    /**
+     * @param days to shift all persons' {@code ShnPeriod} end date by.
+     */
+    public TShiftCommand(int days) {
+        this.days = days;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        if (days == 0) {
+            throw new CommandException(MESSAGE_TSHIFT_BY_ZERO);
+        }
+        if (Math.abs(days) > MAX_ABS_DAYS_VALUE) {
+            throw new CommandException(String.format(MESSAGE_BEYOND_LIMIT, MAX_ABS_DAYS_VALUE));
+        }
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        for (Person personToEdit : lastShownList) {
+            EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
+            personToEdit.getShnPeriod()
+                    .map(this::shiftShnPeriodEndDate)
+                    .ifPresent(editPersonDescriptor::setShnPeriod);
+            Person editedPerson = EditCommand.createEditedPerson(personToEdit, editPersonDescriptor);
+            model.setPerson(personToEdit, editedPerson);
+        }
+
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    /**
+     * Shifts the end date of the specified {@code ShnPeriod} by {@code days}.
+     * @param shnPeriod that will have its end date shifted.
+     * @return A new {@code ShnPeriod} object with its end date shifted.
+     */
+    public ShnPeriod shiftShnPeriodEndDate(ShnPeriod shnPeriod) {
+        LocalDate startDate = shnPeriod.startDate;
+        LocalDate endDate = shnPeriod.endDate;
+
+        assert days != 0;
+
+        LocalDate newEndDate = Collections.max(List.of(endDate.plusDays(days), startDate.plusDays(1)));
+
+        return new ShnPeriod(startDate, newEndDate);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TShiftCommand // instanceof handles nulls
+                && days == (((TShiftCommand) other).days));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.TShiftCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case TShiftCommand.COMMAND_WORD:
+            return new TShiftCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/TShiftCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TShiftCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.TShiftCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code TShiftCommand} object
+ */
+public class TShiftCommandParser implements Parser<TShiftCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code TShiftCommand}
+     * and returns a {@code TShiftCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public TShiftCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        try {
+            int days = Integer.parseInt(args.trim());
+            return new TShiftCommand(days);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TShiftCommand.MESSAGE_USAGE), nfe);
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/TShiftCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TShiftCommandTest.java
@@ -1,0 +1,116 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ShnPeriod;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code TShiftCommand}.
+ */
+public class TShiftCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validDaysShiftPositive() throws CommandException {
+        int days = TShiftCommand.MAX_ABS_DAYS_VALUE;
+
+        TShiftCommand tShiftCommand = new TShiftCommand(days);
+        CommandResult commandResult = tShiftCommand.execute(model);
+        String expectedMessage = TShiftCommand.MESSAGE_SUCCESS;
+        assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
+    }
+
+    @Test
+    public void execute_validDaysShiftNegative() throws CommandException {
+        int days = -TShiftCommand.MAX_ABS_DAYS_VALUE;
+
+        TShiftCommand tShiftCommand = new TShiftCommand(days);
+        CommandResult commandResult = tShiftCommand.execute(model);
+        String expectedMessage = TShiftCommand.MESSAGE_SUCCESS;
+        assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
+    }
+
+    @Test
+    public void execute_zeroDaysShift_throwsCommandException() {
+        TShiftCommand tShiftCommand = new TShiftCommand(0);
+        assertCommandFailure(tShiftCommand, model, TShiftCommand.MESSAGE_TSHIFT_BY_ZERO);
+    }
+
+    @Test
+    public void execute_shiftBeyondLimit_throwsCommandException() {
+        String expectedMessage = String.format(TShiftCommand.MESSAGE_BEYOND_LIMIT, TShiftCommand.MAX_ABS_DAYS_VALUE);
+
+        TShiftCommand tShiftCommandPlus = new TShiftCommand(TShiftCommand.MAX_ABS_DAYS_VALUE + 1);
+        assertCommandFailure(tShiftCommandPlus, model, expectedMessage);
+
+        tShiftCommandPlus = new TShiftCommand(TShiftCommand.MAX_ABS_DAYS_VALUE + 100);
+        assertCommandFailure(tShiftCommandPlus, model, expectedMessage);
+
+        TShiftCommand tShiftCommandMinus = new TShiftCommand(-TShiftCommand.MAX_ABS_DAYS_VALUE - 1);
+        assertCommandFailure(tShiftCommandMinus, model, expectedMessage);
+
+        tShiftCommandMinus = new TShiftCommand(-TShiftCommand.MAX_ABS_DAYS_VALUE - 100);
+        assertCommandFailure(tShiftCommandMinus, model, expectedMessage);
+    }
+
+    @Test
+    public void shiftingDates_validDays() {
+        int days = TShiftCommand.MAX_ABS_DAYS_VALUE;
+        TShiftCommand tShiftCommand = new TShiftCommand(days);
+        ShnPeriod shnPeriod = new ShnPeriod("2020-01-01 => 2020-01-02");
+        ShnPeriod shiftedShnPeriod = tShiftCommand.shiftShnPeriodEndDate(shnPeriod);
+        assertEquals(days, shnPeriod.endDate.until(shiftedShnPeriod.endDate, ChronoUnit.DAYS));
+    }
+
+    @Test
+    public void shiftingDates_validDays_validNegativeShift() {
+        int days = -TShiftCommand.MAX_ABS_DAYS_VALUE;
+        int daysApart = 10;
+        assertTrue(Math.abs(days) > daysApart);
+
+        LocalDate startDate = LocalDate.of(2020, 1, 1);
+        LocalDate endDate = startDate.plusDays(daysApart);
+        TShiftCommand tShiftCommand = new TShiftCommand(days);
+        ShnPeriod shnPeriod = new ShnPeriod(startDate, endDate);
+        ShnPeriod shiftedShnPeriod = tShiftCommand.shiftShnPeriodEndDate(shnPeriod);
+        assertEquals(startDate.plusDays(1), shiftedShnPeriod.endDate);
+    }
+
+    @Test
+    public void equals() {
+        TShiftCommand tShiftCommand1 = new TShiftCommand(-1);
+        TShiftCommand tShiftCommand2 = new TShiftCommand(0);
+        TShiftCommand tShiftCommand3 = new TShiftCommand(1);
+
+        // same object -> returns true
+        assertTrue(tShiftCommand1.equals(tShiftCommand1));
+        assertTrue(tShiftCommand2.equals(tShiftCommand2));
+        assertTrue(tShiftCommand3.equals(tShiftCommand3));
+
+        // different types -> returns false
+        assertFalse(tShiftCommand1.equals(1));
+
+        // null -> returns false
+        assertFalse(tShiftCommand1.equals(null));
+
+        // different person -> returns false
+        assertFalse(tShiftCommand1.equals(tShiftCommand2));
+        assertFalse(tShiftCommand2.equals(tShiftCommand3));
+        assertFalse(tShiftCommand3.equals(tShiftCommand1));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.TShiftCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -86,6 +87,12 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_tshift() throws Exception {
+        assertTrue(parser.parseCommand(TShiftCommand.COMMAND_WORD + " 3") instanceof TShiftCommand);
+        assertTrue(parser.parseCommand(TShiftCommand.COMMAND_WORD + " -3") instanceof TShiftCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/TShiftCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TShiftCommandParserTest.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.TShiftCommand;
+
+public class TShiftCommandParserTest {
+    private final TShiftCommandParser parser = new TShiftCommandParser();
+
+    @Test
+    public void parse_negativeValues() {
+        assertParseSuccess(parser, "-2", new TShiftCommand(-2));
+        assertParseSuccess(parser, " -2", new TShiftCommand(-2));
+        assertParseSuccess(parser, "-2 ", new TShiftCommand(-2));
+        assertParseSuccess(parser, " -2 ", new TShiftCommand(-2));
+
+        assertParseSuccess(parser, "-12345678", new TShiftCommand(-12345678));
+    }
+
+    @Test
+    public void parse_positiveValues() {
+        assertParseSuccess(parser, "2", new TShiftCommand(2));
+        assertParseSuccess(parser, " 2", new TShiftCommand(2));
+        assertParseSuccess(parser, "2 ", new TShiftCommand(2));
+        assertParseSuccess(parser, " 2 ", new TShiftCommand(2));
+
+        assertParseSuccess(parser, "12345678", new TShiftCommand(12345678));
+    }
+
+    @Test
+    public void parse_invalidInputs() {
+        assertParseFailure(parser, " ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TShiftCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "two", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TShiftCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-i ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TShiftCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Merging implements the TShiftCommand for v1.3 of Track2Gather, fixing #78. A sample user guide of the command is below.

**Command Word**: `tshift`

**Command Description**:
Shifts all persons' SHN end dates by the specified number of `DAYS`, postpones the date if the value is positive, brings forward the date if the value is negative. The SHN end dates will only be brought forward up to and including the pesons' SHN start date + 1.

**Format**: `tshift [PLUS_MINUS_SIGN]DAYS`
* `DAYS` should be a number between `1` and `90` inclusive.

**Example**:
* `tshift 3` postpones all SHN end dates by 3 days. This is identical to `tshift +3`.
* `tshift -3` brings forward all SHN end dates by up to 3 days.