### PR TITLE
Implement directional sorting in Sort command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -10,6 +10,7 @@ import java.util.Optional;
  * Stores mapping of prefixes to their respective arguments.
  * Each key may be associated with multiple argument values.
  * Values for a given key are stored in a list, and the insertion ordering is maintained.
+ * Keys are ordered by the index of their last occurrences.
  * Keys are unique, but the list of argument values may contain duplicate argument values, i.e. the same argument value
  * can be inserted multiple times for the same prefix.
  */
@@ -18,7 +19,7 @@ public class ArgumentMultimap {
     /**
      * Prefixes mapped to their respective arguments
      **/
-    private final Map<Prefix, List<String>> argMultimap = new HashMap<>();
+    private final Map<Prefix, List<String>> argMultimap = new LinkedHashMap<>();
 
     /**
      * Associates the specified argument value with {@code prefix} key in this map.
@@ -30,7 +31,20 @@ public class ArgumentMultimap {
     public void put(Prefix prefix, String argValue) {
         List<String> argValues = getAllValues(prefix);
         argValues.add(argValue);
+        // update insertion order of LinkedHashMap by deleting and reinserting prefix
+        // so that the latest prefix is shifted to the end
+        argMultimap.remove(prefix);
         argMultimap.put(prefix, argValues);
+    }
+
+    /**
+     * Returns all prefixes in order of the index of their last occurrences.
+     * Modifying the returned list will not affect the underlying data structure of the ArgumentMultimap.
+     */
+    public List<Prefix> getPrefixes() {
+        List<Prefix> prefixes = new ArrayList<>();
+        argMultimap.forEach((prefix, value) -> prefixes.add(prefix));
+        return prefixes;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.SortCommand.Direction;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -27,60 +28,98 @@ public class SortCommandTest {
 
     @Test
     public void execute_emptyAddressBook_success() {
-        String expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS, "[" + PREFIX_NAME + "]");
+        List<Prefix> prefixes = List.of(PREFIX_NAME);
+        List<Direction> directions = List.of(Direction.ASCENDING);
+        SortCommand sortCommand = new SortCommand(prefixes, directions);
+
+        String expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS,
+                PREFIX_NAME.toString() + Direction.ASCENDING);
 
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        assertCommandSuccess(new SortCommand(List.of(PREFIX_NAME)), model, expectedMessage, expectedModel);
+        assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_singlePrefix_success() {
-        // name
-        SortCommand sortCommand = new SortCommand(List.of(PREFIX_NAME));
+        // name, ascending
+        List<Prefix> prefixes = List.of(PREFIX_NAME);
+        List<Direction> directions = List.of(Direction.ASCENDING);
+        Comparator<Person> comparator = Comparator.comparing(Person::getName);
 
-        String expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS, "[" + PREFIX_NAME + "]");
-
+        SortCommand sortCommand = new SortCommand(prefixes, directions);
+        String expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS,
+                PREFIX_NAME.toString() + Direction.ASCENDING);
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel.updateSortedPersonList(Comparator.comparing(Person::getName));
+        expectedModel.updateSortedPersonList(comparator);
 
         assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
 
-        // case number
-        sortCommand = new SortCommand(List.of(PREFIX_CASE_NUMBER));
+        // case number, ascending
+        prefixes = List.of(PREFIX_CASE_NUMBER);
+        directions = List.of(Direction.ASCENDING);
+        comparator = Comparator.comparing(Person::getCaseNumber);
 
-        expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS, "[" + PREFIX_CASE_NUMBER + "]");
-
+        sortCommand = new SortCommand(prefixes, directions);
+        expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS,
+                PREFIX_CASE_NUMBER.toString() + Direction.ASCENDING);
         expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel.updateSortedPersonList(Comparator.comparing(Person::getCaseNumber));
+        expectedModel.updateSortedPersonList(comparator);
+
+        assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
+
+        // name, descending
+        prefixes = List.of(PREFIX_NAME);
+        directions = List.of(Direction.DESCENDING);
+        comparator = Comparator.comparing(Person::getName).reversed();
+
+        sortCommand = new SortCommand(prefixes, directions);
+        expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS, PREFIX_NAME.toString() + Direction.DESCENDING);
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel.updateSortedPersonList(comparator);
+
+        assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
+
+        // case number, descending
+        prefixes = List.of(PREFIX_CASE_NUMBER);
+        directions = List.of(Direction.DESCENDING);
+        comparator = Comparator.comparing(Person::getCaseNumber).reversed();
+
+        sortCommand = new SortCommand(prefixes, directions);
+        expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS,
+                PREFIX_CASE_NUMBER.toString() + Direction.DESCENDING);
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel.updateSortedPersonList(comparator);
 
         assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_multiplePrefix_success() {
-        // name then case number
-        SortCommand sortCommand = new SortCommand(List.of(PREFIX_NAME, PREFIX_CASE_NUMBER));
+        // name ascending then case number ascending
+        List<Prefix> prefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
+        List<Direction> directions = List.of(Direction.ASCENDING, Direction.ASCENDING);
+        Comparator<Person> comparator = Comparator.comparing(Person::getCaseNumber).thenComparing(Person::getName);
 
-        String expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS, "[" + PREFIX_NAME + ", "
-                + PREFIX_CASE_NUMBER + "]");
-
+        SortCommand sortCommand = new SortCommand(prefixes, directions);
+        String expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS,
+                PREFIX_NAME.toString() + Direction.ASCENDING + " " + PREFIX_CASE_NUMBER + Direction.ASCENDING);
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel.updateSortedPersonList(Comparator.comparing(Person::getCaseNumber)
-                .thenComparing(Person::getName));
+        expectedModel.updateSortedPersonList(comparator);
 
         assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
 
-        // case number then name
-        sortCommand = new SortCommand(List.of(PREFIX_CASE_NUMBER, PREFIX_NAME));
+        // case number ascending then name descending
+        prefixes = List.of(PREFIX_CASE_NUMBER, PREFIX_NAME);
+        directions = List.of(Direction.ASCENDING, Direction.DESCENDING);
+        comparator = Comparator.comparing(Person::getName).reversed().thenComparing(Person::getCaseNumber);
 
-        expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS, "[" + PREFIX_CASE_NUMBER + ", " + PREFIX_NAME
-                + "]");
-
+        sortCommand = new SortCommand(prefixes, directions);
+        expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS,
+                PREFIX_CASE_NUMBER.toString() + Direction.ASCENDING + " " + PREFIX_NAME + Direction.DESCENDING);
         expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel.updateSortedPersonList(Comparator.comparing(Person::getName)
-                .thenComparing(Person::getCaseNumber));
+        expectedModel.updateSortedPersonList(comparator);
 
         assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
     }
@@ -88,16 +127,19 @@ public class SortCommandTest {
     @Test
     public void equals() {
         List<Prefix> firstPrefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
-        SortCommand sortFirstCommand = new SortCommand(firstPrefixes);
-
         List<Prefix> secondPrefixes = List.of(PREFIX_CASE_NUMBER, PREFIX_NAME);
-        SortCommand sortSecondCommand = new SortCommand(secondPrefixes);
+        List<Direction> firstDirections = List.of(Direction.ASCENDING, Direction.ASCENDING);
+        List<Direction> secondDirections = List.of(Direction.ASCENDING, Direction.DESCENDING);
+
+        SortCommand sortFirstCommand = new SortCommand(firstPrefixes, firstDirections);
+        SortCommand sortSecondCommand = new SortCommand(secondPrefixes, firstDirections);
+        SortCommand sortThirdCommand = new SortCommand(firstPrefixes, secondDirections);
 
         // same object -> returns true
         assertTrue(sortFirstCommand.equals(sortFirstCommand));
 
         // same values -> returns true
-        SortCommand sortFirstCommandCopy = new SortCommand(firstPrefixes);
+        SortCommand sortFirstCommandCopy = new SortCommand(firstPrefixes, firstDirections);
         assertTrue(sortFirstCommand.equals(sortFirstCommandCopy));
 
         // different types -> returns false
@@ -106,8 +148,11 @@ public class SortCommandTest {
         // null -> returns false
         assertFalse(sortFirstCommand.equals(null));
 
-        // different person -> returns false
+        // different prefixes -> returns false
         assertFalse(sortFirstCommand.equals(sortSecondCommand));
+
+        // different directions -> returns false
+        assertFalse(sortFirstCommand.equals(sortThirdCommand));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +28,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.SortCommand.Direction;
 import seedu.address.logic.commands.TShiftCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
@@ -99,9 +101,15 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_sort() throws Exception {
         List<Prefix> prefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
-        SortCommand command = (SortCommand) parser.parseCommand(SortCommand.COMMAND_WORD + " "
-                + prefixes.stream().map(Object::toString).collect(Collectors.joining(" ")));
-        assertEquals(new SortCommand(prefixes), command);
+        List<Direction> directions = List.of(Direction.ASCENDING, Direction.DESCENDING);
+        assertTrue(prefixes.size() > 0);
+        assertTrue(prefixes.size() == directions.size());
+
+        String sortsString = IntStream.range(0, prefixes.size())
+                .mapToObj(i -> prefixes.get(i).toString() + directions.get(i))
+                .collect(Collectors.joining(" "));
+        SortCommand command = (SortCommand) parser.parseCommand(SortCommand.COMMAND_WORD + " " + sortsString);
+        assertEquals(new SortCommand(prefixes, directions), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,17 +1,10 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.SortCommand.SUPPORTED_PREFIXES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CASE_NUMBER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_HOME_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_QUARANTINE_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SHN_PERIOD;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_WORK_ADDRESS;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -20,6 +13,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.SortCommand.Direction;
 
 public class SortCommandParserTest {
 
@@ -50,27 +44,9 @@ public class SortCommandParserTest {
 
     @Test
     public void parse_invalidPrefix_failure() {
-        // unsupported sort by phone
-        assertParseFailure(parser, PREFIX_PHONE.toString(), MESSAGE_INVALID_FORMAT);
-        // unsupported sort by email
-        assertParseFailure(parser, PREFIX_EMAIL.toString(), MESSAGE_INVALID_FORMAT);
-        // unsupported sort by home address
-        assertParseFailure(parser, PREFIX_HOME_ADDRESS.toString(), MESSAGE_INVALID_FORMAT);
-        // unsupported sort by work address
-        assertParseFailure(parser, PREFIX_WORK_ADDRESS.toString(), MESSAGE_INVALID_FORMAT);
-        // unsupported sort by quarantine address
-        assertParseFailure(parser, PREFIX_QUARANTINE_ADDRESS.toString(), MESSAGE_INVALID_FORMAT);
-        // unsupported sort by SHN period
-        assertParseFailure(parser, PREFIX_SHN_PERIOD.toString(), MESSAGE_INVALID_FORMAT);
-        // unsupported sort by next of kin name
-        assertParseFailure(parser, PREFIX_NEXT_OF_KIN_NAME.toString(), MESSAGE_INVALID_FORMAT);
-        // unsupported sort by next of kin phone
-        assertParseFailure(parser, PREFIX_NEXT_OF_KIN_PHONE.toString(), MESSAGE_INVALID_FORMAT);
-        // unsupported sort by next of kin address
-        assertParseFailure(parser, PREFIX_NEXT_OF_KIN_ADDRESS.toString(), MESSAGE_INVALID_FORMAT);
-
         // invalid prefix
         Prefix invalidPrefix = new Prefix("abc123/");
+        assertFalse(SUPPORTED_PREFIXES.contains(invalidPrefix));
         assertParseFailure(parser, invalidPrefix.toString(), MESSAGE_INVALID_FORMAT);
 
         // invalid prefix with other valid prefixes specified
@@ -81,51 +57,165 @@ public class SortCommandParserTest {
     }
 
     @Test
-    public void parse_onePrefixSpecified_success() {
+    public void parse_onePrefixWithoutDirection_success() {
         // name
-        String userInput = PREFIX_NAME.toString();
-        SortCommand expectedCommand = new SortCommand(List.of(PREFIX_NAME));
+        String userInput = " " + PREFIX_NAME;
+        SortCommand expectedCommand = new SortCommand(List.of(PREFIX_NAME), List.of(Direction.ASCENDING));
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // case number
-        userInput = PREFIX_CASE_NUMBER.toString();
-        expectedCommand = new SortCommand(List.of(PREFIX_CASE_NUMBER));
+        userInput = " " + PREFIX_CASE_NUMBER;
+        expectedCommand = new SortCommand(List.of(PREFIX_CASE_NUMBER), List.of(Direction.ASCENDING));
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
-    public void parse_multiplePrefixesSpecified_success() {
+    public void parse_onePrefixWithDirection_success() {
+        // name ascending
+        String userInput = " " + PREFIX_NAME + Direction.ASCENDING;
+        SortCommand expectedCommand = new SortCommand(List.of(PREFIX_NAME), List.of(Direction.ASCENDING));
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // name descending
+        userInput = " " + PREFIX_NAME + Direction.DESCENDING;
+        expectedCommand = new SortCommand(List.of(PREFIX_NAME), List.of(Direction.DESCENDING));
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // case number ascending
+        userInput = " " + PREFIX_CASE_NUMBER + Direction.ASCENDING;
+        expectedCommand = new SortCommand(List.of(PREFIX_CASE_NUMBER), List.of(Direction.ASCENDING));
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // case number descending
+        userInput = " " + PREFIX_CASE_NUMBER + Direction.DESCENDING;
+        expectedCommand = new SortCommand(List.of(PREFIX_CASE_NUMBER), List.of(Direction.DESCENDING));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multiplePrefixesWithoutDirection_success() {
+        List<Direction> directions = List.of(Direction.ASCENDING, Direction.ASCENDING);
+
         // name then case number
-        String userInput = PREFIX_NAME + " " + PREFIX_CASE_NUMBER;
-        SortCommand expectedCommand = new SortCommand(List.of(PREFIX_NAME, PREFIX_CASE_NUMBER));
+        List<Prefix> prefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
+        String userInput = " " + PREFIX_NAME + " " + PREFIX_CASE_NUMBER;
+        SortCommand expectedCommand = new SortCommand(prefixes, directions);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // case number then name
-        userInput = PREFIX_CASE_NUMBER + " " + PREFIX_NAME;
-        expectedCommand = new SortCommand(List.of(PREFIX_CASE_NUMBER, PREFIX_NAME));
+        prefixes = List.of(PREFIX_CASE_NUMBER, PREFIX_NAME);
+        userInput = " " + PREFIX_CASE_NUMBER + " " + PREFIX_NAME;
+        expectedCommand = new SortCommand(prefixes, directions);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multiplePrefixesWithDirection_success() {
+        // name ascending then case number ascending
+        List<Prefix> prefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
+        List<Direction> directions = List.of(Direction.ASCENDING, Direction.ASCENDING);
+        String userInput = " " + PREFIX_NAME + Direction.ASCENDING + " " + PREFIX_CASE_NUMBER + Direction.ASCENDING;
+        SortCommand expectedCommand = new SortCommand(prefixes, directions);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // name ascending then case number descending
+        prefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
+        directions = List.of(Direction.ASCENDING, Direction.DESCENDING);
+        userInput = " " + PREFIX_NAME + Direction.ASCENDING + " " + PREFIX_CASE_NUMBER + Direction.DESCENDING;
+        expectedCommand = new SortCommand(prefixes, directions);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // name descending then case number descending
+        prefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
+        directions = List.of(Direction.DESCENDING, Direction.DESCENDING);
+        userInput = " " + PREFIX_NAME + Direction.DESCENDING + " " + PREFIX_CASE_NUMBER + Direction.DESCENDING;
+        expectedCommand = new SortCommand(prefixes, directions);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multiplePrefixesMixedWithDirection_success() {
+        // name then case number ascending
+        List<Prefix> prefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
+        List<Direction> directions = List.of(Direction.ASCENDING, Direction.ASCENDING);
+        String userInput = " " + PREFIX_NAME + " " + PREFIX_CASE_NUMBER + Direction.ASCENDING;
+        SortCommand expectedCommand = new SortCommand(prefixes, directions);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // name ascending then case number
+        prefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
+        directions = List.of(Direction.ASCENDING, Direction.ASCENDING);
+        userInput = " " + PREFIX_NAME + Direction.ASCENDING + " " + PREFIX_CASE_NUMBER;
+        expectedCommand = new SortCommand(prefixes, directions);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // name then case number descending
+        prefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
+        directions = List.of(Direction.ASCENDING, Direction.DESCENDING);
+        userInput = " " + PREFIX_NAME + " " + PREFIX_CASE_NUMBER + Direction.DESCENDING;
+        expectedCommand = new SortCommand(prefixes, directions);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // name descending then case number
+        prefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
+        directions = List.of(Direction.DESCENDING, Direction.ASCENDING);
+        userInput = " " + PREFIX_NAME + Direction.DESCENDING + " " + PREFIX_CASE_NUMBER;
+        expectedCommand = new SortCommand(prefixes, directions);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
     public void parse_multipleRepeatedPrefixes_acceptsLast() {
-        // same prefix repeated
-        String userInput = PREFIX_NAME + " " + PREFIX_NAME;
-        SortCommand expectedCommand = new SortCommand(List.of(PREFIX_NAME));
+        // single prefix repeated
+        List<Prefix> prefixes = List.of(PREFIX_NAME);
+        List<Direction> directions = List.of(Direction.ASCENDING);
+        String userInput = " " + PREFIX_NAME + " " + PREFIX_NAME;
+        SortCommand expectedCommand = new SortCommand(prefixes, directions);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // same prefix repeated, accepting last occurrence
+        prefixes = List.of(PREFIX_NAME);
+        directions = List.of(Direction.DESCENDING);
+        userInput = " " + PREFIX_NAME + " " + PREFIX_NAME + Direction.DESCENDING;
+        expectedCommand = new SortCommand(prefixes, directions);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        prefixes = List.of(PREFIX_NAME);
+        directions = List.of(Direction.ASCENDING);
+        userInput = " " + PREFIX_NAME + Direction.DESCENDING + " " + PREFIX_NAME + Direction.ASCENDING;
+        expectedCommand = new SortCommand(prefixes, directions);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        prefixes = List.of(PREFIX_NAME);
+        directions = List.of(Direction.ASCENDING);
+        userInput = " " + PREFIX_NAME + Direction.DESCENDING + " " + PREFIX_NAME;
+        expectedCommand = new SortCommand(prefixes, directions);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // single prefix repeated with rest of prefixes unique
-        userInput = PREFIX_CASE_NUMBER + " " + PREFIX_NAME + " " + PREFIX_CASE_NUMBER;
-        expectedCommand = new SortCommand(List.of(PREFIX_NAME, PREFIX_CASE_NUMBER));
+        prefixes = List.of(PREFIX_NAME, PREFIX_CASE_NUMBER);
+        directions = List.of(Direction.ASCENDING, Direction.ASCENDING);
+        userInput = " " + PREFIX_CASE_NUMBER + Direction.DESCENDING + " " + PREFIX_NAME + " " + PREFIX_CASE_NUMBER;
+        expectedCommand = new SortCommand(prefixes, directions);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        userInput = PREFIX_NAME + " " + PREFIX_CASE_NUMBER + " " + PREFIX_NAME;
-        expectedCommand = new SortCommand(List.of(PREFIX_CASE_NUMBER, PREFIX_NAME));
+        prefixes = List.of(PREFIX_CASE_NUMBER, PREFIX_NAME);
+        directions = List.of(Direction.ASCENDING, Direction.ASCENDING);
+        userInput = " " + PREFIX_NAME + Direction.DESCENDING + " " + PREFIX_CASE_NUMBER + " " + PREFIX_NAME;
+        expectedCommand = new SortCommand(prefixes, directions);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // multiple prefix repeated
-        userInput = PREFIX_NAME + " " + PREFIX_CASE_NUMBER + " " + PREFIX_NAME + " " + PREFIX_NAME + " "
-                + PREFIX_CASE_NUMBER + " " + PREFIX_NAME;
-        expectedCommand = new SortCommand(List.of(PREFIX_CASE_NUMBER, PREFIX_NAME));
+        // multiple prefixes repeated
+        prefixes = List.of(PREFIX_CASE_NUMBER, PREFIX_NAME);
+        directions = List.of(Direction.ASCENDING, Direction.DESCENDING);
+        userInput = " " + PREFIX_NAME
+                + " " + PREFIX_CASE_NUMBER + Direction.DESCENDING
+                + " " + PREFIX_NAME + Direction.ASCENDING
+                + " " + PREFIX_NAME
+                + " " + PREFIX_CASE_NUMBER
+                + " " + PREFIX_CASE_NUMBER + Direction.ASCENDING
+                + " " + PREFIX_NAME + Direction.DESCENDING;
+        expectedCommand = new SortCommand(prefixes, directions);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 


### PR DESCRIPTION
This commit modifies the previous approach of input parsing to use
ArgumentMultimap. This required a change to the internal data structure
from HashMap to LinkedHashMap, which would preserve the insertion order
of prefixes. An additional method, getPrefixes(), has been created in
ArgumentMultimap to return a list of prefixes ordered by index of last
occurrence.