### PR TITLE
Find command v1.3: Edit Name Predicate

### DIFF
--- a/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
@@ -3,11 +3,10 @@ package seedu.address.model.person.predicates;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Person;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code Name} contains any of the keywords given.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
@@ -18,8 +17,9 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        String nameIgnoreCase = person.getName().fullName.toLowerCase();
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> nameIgnoreCase.contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/test/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicateTest.java
@@ -41,19 +41,19 @@ public class NameContainsKeywordsPredicateTest {
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Ali"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Multiple keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Ali", "Bob"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Only one matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Car"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
 
         // Mixed-case keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLI", "bOB"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 


### PR DESCRIPTION
Closes #120.

Current `NameContainsKeywordsPredicate` returns `true` when a word in the name is exactly equals to a keyword. 

This is an issue as users are required to know the exact name of a person in order to find the person. 

Changing this predicate to return `true` when name contains a keyword among the specified keyword(s) will allow for a more flexible search.