### PR TITLE
Delete command: Allow indices in any order

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,7 +7,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index(s) provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -8,7 +8,7 @@ package seedu.address.commons.core.index;
  * base the other component is using for its index. However, after receiving the {@code Index}, that component can
  * convert it back to an int if the index will not be passed to a different component again.
  */
-public class Index {
+public class Index implements Comparable<Index> {
     private int zeroBasedIndex;
 
     /**
@@ -43,6 +43,10 @@ public class Index {
      */
     public static Index fromOneBased(int oneBasedIndex) {
         return new Index(oneBasedIndex - 1);
+    }
+
+    public int compareTo(Index other) {
+        return Integer.compare(zeroBasedIndex, other.zeroBasedIndex);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -3,7 +3,9 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -12,7 +14,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Deletes a person identified using it's displayed index from the address book.
+ * Deletes a person identified using its displayed index from the address book.
  */
 public class DeleteCommand extends Command {
 
@@ -20,14 +22,18 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person(s) identified by the index number(s) used in the displayed person list.\n"
-            + "Parameters: INDEX [MORE_INDICES] (must be positive integers and in ascending order)\n"
+            + "Parameters: INDEX [MORE_INDICES] (must be positive integers)\n"
             + "Example: " + COMMAND_WORD + " 1 2";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person(s):";
 
     private final ArrayList<Index> targetIndices;
 
+    /**
+     * Creates a DeleteCommand to delete the specified {@code Person}(s)
+     */
     public DeleteCommand(ArrayList<Index> targetIndices) {
+        targetIndices.sort(Comparator.reverseOrder());
         this.targetIndices = targetIndices;
     }
 
@@ -36,22 +42,18 @@ public class DeleteCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
         String commandResult = MESSAGE_DELETE_PERSON_SUCCESS;
+        ArrayList<String> commandResultList = new ArrayList<>();
 
         for (Index targetIndex : targetIndices) {
-            // shift index by the number of entries that were deleted prior to it
-            int shiftedIndex = targetIndex.getZeroBased() - targetIndices.indexOf(targetIndex);
-            targetIndex = Index.fromZeroBased(shiftedIndex);
-
             if (targetIndex.getZeroBased() >= lastShownList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
 
             Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
             model.deletePerson(personToDelete);
-            commandResult += personToDelete + ", ";
+            commandResultList.add(0, personToDelete.toString());
         }
-        // remove unnecessary final ", " in the commandResult
-        commandResult = commandResult.substring(0, commandResult.length() - 2);
+        commandResult += commandResultList.stream().collect(Collectors.joining("; "));
 
         return new CommandResult(commandResult);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -54,6 +54,7 @@ public class ParserUtil {
 
             indexList.add(Index.fromOneBased(Integer.parseInt(trimmedIndex)));
         }
+
         return indexList;
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
@@ -39,6 +40,66 @@ public class DeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndicesUnfilteredListInAscendingOrder_success() {
+        Person firstPersonToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person secondPersonToDelete = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        ArrayList<Index> indicesMultiplePersons = new ArrayList<>();
+        indicesMultiplePersons.add(INDEX_FIRST_PERSON);
+        indicesMultiplePersons.add(INDEX_SECOND_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(indicesMultiplePersons);
+
+        String expectedMessage = DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS + firstPersonToDelete + "; "
+                + secondPersonToDelete;
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(firstPersonToDelete);
+        expectedModel.deletePerson(secondPersonToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndicesUnfilteredListInDescendingOrder_success() {
+        Person firstPersonToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person secondPersonToDelete = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        ArrayList<Index> indicesMultiplePersons = new ArrayList<>();
+        indicesMultiplePersons.add(INDEX_SECOND_PERSON);
+        indicesMultiplePersons.add(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(indicesMultiplePersons);
+
+        String expectedMessage = DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS + firstPersonToDelete + "; "
+                + secondPersonToDelete;
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(firstPersonToDelete);
+        expectedModel.deletePerson(secondPersonToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndicesUnfilteredListInMixedOrder_success() {
+        Person firstPersonToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person secondPersonToDelete = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        Person thirdPersonToDelete = model.getFilteredPersonList().get(INDEX_THIRD_PERSON.getZeroBased());
+        ArrayList<Index> indicesMultiplePersons = new ArrayList<>();
+        indicesMultiplePersons.add(INDEX_THIRD_PERSON);
+        indicesMultiplePersons.add(INDEX_FIRST_PERSON);
+        indicesMultiplePersons.add(INDEX_SECOND_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(indicesMultiplePersons);
+
+        String expectedMessage = DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS + firstPersonToDelete + "; "
+                + secondPersonToDelete + "; " + thirdPersonToDelete;
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(firstPersonToDelete);
+        expectedModel.deletePerson(secondPersonToDelete);
+        expectedModel.deletePerson(thirdPersonToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
Indices could only be provided in ascending order.

Changing it to allow any order will make it more user-friendly.

Let's change the Delete command to take indices in any given order.