### PR TITLE
Delete command: Update UG and DG to reflect any-order deletion

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -460,10 +460,13 @@ testers are expected to do more *exploratory* testing.
    3. Test case: `delete 1 2`<br>
       Expected: First and second persons are deleted from the list. Details of the deleted persons shown in the status message. Timestamp in the status bar is updated.
 
-   4. Test case: `delete 0`<br>
+   4. Test case: `delete 3 1 2`<br>
+      Expected: First, second and third persons are deleted from the list. Details of the deleted persons shown in the status message. Timestamp in the status bar is updated.
+
+   5. Test case: `delete 0`<br>
       Expected: No person is deleted. Error details shown in the status message. Status bar remains the same.
 
-   5. Other incorrect delete commands to try: `delete`, `delete x` (where x is larger than the list size), `delete a b` (where a and b are in descending order), `...` <br>
+   6. Other incorrect delete commands to try: `delete`, `delete x` (where x is larger than the list size), `...` <br>
       Expected: Similar to previous.
 
 2. Deleting a person while search results are being shown
@@ -475,10 +478,13 @@ testers are expected to do more *exploratory* testing.
    3. Test case: `delete 1 2`<br>
       Expected: First and second persons displayed in the search results are deleted from the application. Details of the deleted persons shown in the status message. Timestamp in the status bar is updated.
 
-   4. Test case: `delete 0`<br>
+   4. Test case: `delete 3 1 2`<br>
+      Expected: First, second and third persons displayed in the search results are deleted from the application. Details of the deleted persons shown in the status message. Timestamp in the status bar is updated.
+
+   5. Test case: `delete 0`<br>
       Expected: No person is deleted. Error details shown in the status message. Status bar remains the same.
 
-   5. Other incorrect delete commands to try: `delete`, `delete x` (where x is larger than the list size), `delete a b` (where a and b are in descending order), `...` <br>
+   6. Other incorrect delete commands to try: `delete`, `delete x` (where x is larger than the list size), `...` <br>
       Expected: Similar to previous.
 
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -118,8 +118,8 @@ Format: `delete INDEX [MORE_INDICES]`
 
 * Deletes the contact(s) at the specified `INDEX`(s).
 * The index(s) **must be a positive integer** (e.g. 1, 2, 3, ..)
-* The index(s) **must be given in ascending order** (e.g. `delete 1 4 5`)
 * The index(s) **must not exceed the total number of contacts** in the address book
+* The index(s) **can be given in any order** (e.g. `delete 1 4 5`, `delete 5 1 4`)
 
 Examples:
 * `sort` followed by `delete 2` deletes the 2nd person in the contacts list when sorted by name. 


### PR DESCRIPTION
UG and DG were not reflective of the any-order deletion.

Updating UG and DG to reflect the change in the Delete command maintains the documentation accuracy.

Let's update the UG and DG to reflect the any-order deletion