### PR TITLE
Update find command error messages and tests

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -86,7 +86,7 @@ Refer to the [Features](#features) below for details of each command.
 Field | Format
 ------|------------------
 `NAME` | Names should only contain alphanumeric characters and spaces, and should not be blank.
-`PHONE_NUMBER` | Phone numbers should only contain numbers and should be at least 3 digits long.
+`PHONE_NUMBER` | Phone numbers should only contain integers and should be at least 3 digits long.
 `EMAIL` | Emails should be of the format local-part@domain. <br> The local-part should only contain alphanumeric characters and these special characters, excluding the parentheses, (+_.-). The local-part may not start or end with any special characters. This is followed by a '@' and then a domain name. <br> The domain name is made up of domain labels separated by periods. The domain name must end with a domain label at least 2 characters long, have each domain label start and end with alphanumeric characters and must have each domain label consist of alphanumeric characters, separated only by hyphens, if any.
 `CASE_NUMBER` | Case numbers should be input as positive integers with no leading zeros. Case numbers can be anywhere from 1 to 6 digits long. Note that case numbers are displayed in a fixed format of 6 digits, padded with zeros on the left, if needed.
 `HOME_ADDRESS` | Addresses can be any non-empty string of characters.
@@ -94,7 +94,7 @@ Field | Format
 `QUARANTINE_ADDRESS` | Addresses can be any non-empty string of characters.
 `SHN_PERIOD` | SHN periods should comprise of two dates in the [ISO-8601 format](https://www.iso.org/iso-8601-date-and-time-format.html) (i.e. yyyy-MM-dd), separated by a space. The start date should be keyed before the end date, and must occur earlier than the end date by at least 1 day.
 `NEXT_OF_KIN_NAME` | Names should only contain alphanumeric characters and spaces, and should not be blank.
-`NEXT_OF_KIN_PHONE` | Phone numbers should only contain numbers and should be at least 3 digits long.
+`NEXT_OF_KIN_PHONE` | Phone numbers should only contain integers and should be at least 3 digits long.
 `NEXT_OF_KIN_ADDRESS` | Addresses can be any non-empty string of characters.
 
 ### Adding a person: `add`

--- a/src/main/java/seedu/track2gather/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/track2gather/logic/parser/FindCommandParser.java
@@ -15,7 +15,9 @@ import java.util.stream.Stream;
 import seedu.track2gather.logic.commands.FindCommand;
 import seedu.track2gather.logic.parser.exceptions.ParseException;
 import seedu.track2gather.model.person.attributes.CaseNumber;
+import seedu.track2gather.model.person.attributes.Name;
 import seedu.track2gather.model.person.attributes.Period;
+import seedu.track2gather.model.person.attributes.Phone;
 import seedu.track2gather.model.person.predicates.CaseNumberEqualsKeywordsPredicate;
 import seedu.track2gather.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.track2gather.model.person.predicates.PhoneStartsWithKeywordsPredicate;
@@ -56,17 +58,25 @@ public class FindCommandParser implements Parser<FindCommand> {
         String[] keywords = value.split("\\s+");
         List<String> keywordList = Arrays.asList(keywords);
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            boolean areValidNames = keywordList.stream().allMatch(Name::isValidName);
+            if (!areValidNames) {
+                throw new ParseException(Name.MESSAGE_CONSTRAINTS_KEYWORDS);
+            }
             return new FindCommand(new NameContainsKeywordsPredicate(keywordList));
         }
 
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            boolean areValidPhones = keywordList.stream().allMatch(Phone::isValidPhoneKeyword);
+            if (!areValidPhones) {
+                throw new ParseException(Phone.MESSAGE_CONSTRAINTS_KEYWORDS);
+            }
             return new FindCommand(new PhoneStartsWithKeywordsPredicate(keywordList));
         }
 
         if (argMultimap.getValue(PREFIX_CASE_NUMBER).isPresent()) {
             boolean areValidCaseNumbers = keywordList.stream().allMatch(CaseNumber::isValidCaseNumber);
             if (!areValidCaseNumbers) {
-                throw new ParseException(CaseNumber.MESSAGE_CONSTRAINTS);
+                throw new ParseException(CaseNumber.MESSAGE_CONSTRAINTS_KEYWORDS);
             }
             return new FindCommand(new CaseNumberEqualsKeywordsPredicate(keywordList));
         }
@@ -74,7 +84,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_SHN_PERIOD_START).isPresent()) {
             boolean areValidDates = keywordList.stream().allMatch(Period::isValidDate);
             if (!areValidDates) {
-                throw new ParseException(Period.MESSAGE_CONSTRAINTS_DATE);
+                throw new ParseException(Period.MESSAGE_CONSTRAINTS_DATE_KEYWORDS);
             }
             return new FindCommand(new ShnPeriodStartEqualsKeywordsPredicate(keywordList));
         }
@@ -82,7 +92,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_SHN_PERIOD_END).isPresent()) {
             boolean areValidDates = keywordList.stream().allMatch(Period::isValidDate);
             if (!areValidDates) {
-                throw new ParseException(Period.MESSAGE_CONSTRAINTS_DATE);
+                throw new ParseException(Period.MESSAGE_CONSTRAINTS_DATE_KEYWORDS);
             }
             return new FindCommand(new ShnPeriodEndEqualsKeywordsPredicate(keywordList));
         }

--- a/src/main/java/seedu/track2gather/model/person/attributes/CaseNumber.java
+++ b/src/main/java/seedu/track2gather/model/person/attributes/CaseNumber.java
@@ -7,8 +7,10 @@ import static seedu.track2gather.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidCaseNumber(String)}
  */
 public class CaseNumber extends Attribute<String> implements Comparable<CaseNumber> {
-    public static final String MESSAGE_CONSTRAINTS =
-            "Case number should be a positive integer with no leading zeros and at most 6 digits";
+    public static final String MESSAGE_CONSTRAINTS = "Case numbers should contain only positive integers with no "
+            + "leading zeros, and must be between 1 to 6 digits long.";
+    public static final String MESSAGE_CONSTRAINTS_KEYWORDS = "Case number keywords should contain only positive "
+            + "integers with no leading zeros, and must be between 1 to 6 digits long.";
     public static final String VALIDATION_REGEX = "^[1-9]\\d{0,5}$";
 
     /**

--- a/src/main/java/seedu/track2gather/model/person/attributes/Name.java
+++ b/src/main/java/seedu/track2gather/model/person/attributes/Name.java
@@ -10,6 +10,8 @@ public class Name extends Attribute<String> implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS_KEYWORDS =
+            "Name keywords should only contain alphanumeric characters and spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/seedu/track2gather/model/person/attributes/Period.java
+++ b/src/main/java/seedu/track2gather/model/person/attributes/Period.java
@@ -18,7 +18,9 @@ public class Period extends Attribute<Pair<LocalDate, LocalDate>> {
                     + "separated by a space. Start date should be keyed before the end date, "
                     + "and must occur earlier than the end date by at least 1 second.";
     public static final String MESSAGE_CONSTRAINTS_DATE =
-            "Date should be in the ISO-8601 format (i.e. yyyy-MM-dd)";
+            "Dates should be in the ISO-8601 format (i.e. yyyy-MM-dd)";
+    public static final String MESSAGE_CONSTRAINTS_DATE_KEYWORDS =
+            "Date keywords should be in the ISO-8601 format (i.e. yyyy-MM-dd)";
 
     /**
      * Constructs a {@code Period}.

--- a/src/main/java/seedu/track2gather/model/person/attributes/Phone.java
+++ b/src/main/java/seedu/track2gather/model/person/attributes/Phone.java
@@ -9,8 +9,11 @@ import static seedu.track2gather.commons.util.AppUtil.checkArgument;
 public class Phone extends Attribute<String> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
+            "Phone numbers should only contain integers, and should be at least 3 digits long";
+    public static final String MESSAGE_CONSTRAINTS_KEYWORDS =
+            "Phone number keywords should only contain integers, and should be at least 1 digit long";
     public static final String VALIDATION_REGEX = "\\d{3,}";
+    public static final String VALIDATION_REGEX_KEYWORD = "\\d{1,}";
 
     /**
      * Constructs a {@code Phone}.
@@ -27,6 +30,13 @@ public class Phone extends Attribute<String> {
      */
     public static boolean isValidPhone(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a given string is a valid phone number keyword.
+     */
+    public static boolean isValidPhoneKeyword(String test) {
+        return test.matches(VALIDATION_REGEX_KEYWORD);
     }
 
     @Override

--- a/src/test/java/seedu/track2gather/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/track2gather/logic/commands/FindCommandTest.java
@@ -24,8 +24,6 @@ import seedu.track2gather.model.person.predicates.NameContainsKeywordsPredicate;
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private Model model = new ModelManager(getTypicalTrack2Gather(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalTrack2Gather(), new UserPrefs());
 
     @Test
     public void equals() {
@@ -56,6 +54,9 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
+        Model model = new ModelManager(getTypicalTrack2Gather(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getTrack2Gather(), new UserPrefs());
+
         String expectedMessage = String.format(MESSAGE_PERSONS_FOUND_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
         FindCommand command = new FindCommand(predicate);
@@ -66,6 +67,9 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
+        Model model = new ModelManager(getTypicalTrack2Gather(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getTrack2Gather(), new UserPrefs());
+
         String expectedMessage = String.format(MESSAGE_PERSONS_FOUND_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);

--- a/src/test/java/seedu/track2gather/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/track2gather/logic/parser/FindCommandParserTest.java
@@ -15,7 +15,9 @@ import org.junit.jupiter.api.Test;
 
 import seedu.track2gather.logic.commands.FindCommand;
 import seedu.track2gather.model.person.attributes.CaseNumber;
+import seedu.track2gather.model.person.attributes.Name;
 import seedu.track2gather.model.person.attributes.Period;
+import seedu.track2gather.model.person.attributes.Phone;
 import seedu.track2gather.model.person.predicates.CaseNumberEqualsKeywordsPredicate;
 import seedu.track2gather.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.track2gather.model.person.predicates.PhoneStartsWithKeywordsPredicate;
@@ -54,7 +56,7 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validNameArgs_returnsFindCommand() {
+    public void parse_validNameArgs_success() {
         // no leading and trailing whitespaces after prefix
         FindCommand expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
@@ -67,7 +69,18 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validPhoneArgs_returnsFindCommand() {
+    public void parse_invalidNameArgs_throwsParseException() {
+        // One invalid keyword
+        String invalidKeyword = " " + PREFIX_NAME + "Alex-Yeoh";
+        assertParseFailure(parser, invalidKeyword, Name.MESSAGE_CONSTRAINTS_KEYWORDS);
+
+        // One valid and one invalid keyword
+        String invalidTestInput = " " + PREFIX_NAME + "Alex Alex-Yeoh";
+        assertParseFailure(parser, invalidTestInput, Name.MESSAGE_CONSTRAINTS_KEYWORDS);
+    }
+
+    @Test
+    public void parse_validPhoneArgs_success() {
         // no leading and trailing whitespaces after prefix
         FindCommand expectedFindCommand =
                 new FindCommand(new PhoneStartsWithKeywordsPredicate(Arrays.asList("111", "222")));
@@ -81,7 +94,18 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validCaseNumberArgs_returnsFindCommand() {
+    public void parse_invalidPhoneArgs_throwsParseException() {
+        // One invalid keyword
+        String invalidKeyword = " " + PREFIX_PHONE + "abc";
+        assertParseFailure(parser, invalidKeyword, Phone.MESSAGE_CONSTRAINTS_KEYWORDS);
+
+        // One valid and one invalid keyword
+        String invalidTestInput = " " + PREFIX_PHONE + "12 abc";
+        assertParseFailure(parser, invalidTestInput, Phone.MESSAGE_CONSTRAINTS_KEYWORDS);
+    }
+
+    @Test
+    public void parse_validCaseNumberArgs_success() {
         // no leading and trailing whitespaces after prefix
         FindCommand expectedFindCommand =
                 new FindCommand(new CaseNumberEqualsKeywordsPredicate(Arrays.asList("111", "222")));
@@ -95,18 +119,18 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_invalidCaseNumberArgs_returnsFindCommand() {
+    public void parse_invalidCaseNumberArgs_throwsParseException() {
         // One invalid keyword
         String invalidKeyword = " " + PREFIX_CASE_NUMBER + "-1";
-        assertParseFailure(parser, invalidKeyword, CaseNumber.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, invalidKeyword, CaseNumber.MESSAGE_CONSTRAINTS_KEYWORDS);
 
         // One valid and one invalid keyword
         String invalidTestInput = " " + PREFIX_CASE_NUMBER + "1 -1";
-        assertParseFailure(parser, invalidTestInput, CaseNumber.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, invalidTestInput, CaseNumber.MESSAGE_CONSTRAINTS_KEYWORDS);
     }
 
     @Test
-    public void parse_validShnPeriodStartArgs_returnsFindCommand() {
+    public void parse_validShnPeriodStartArgs_success() {
         // no leading and trailing whitespaces after prefix
         FindCommand expectedFindCommand =
                 new FindCommand(new ShnPeriodStartEqualsKeywordsPredicate(Arrays.asList("2000-01-01",
@@ -122,18 +146,18 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_invalidShnPeriodStartArgs_returnsFindCommand() {
+    public void parse_invalidShnPeriodStartArgs_throwsParseException() {
         // One invalid keyword
         String invalidKeyword = " " + PREFIX_SHN_PERIOD_START + "2000/01/01";
-        assertParseFailure(parser, invalidKeyword, Period.MESSAGE_CONSTRAINTS_DATE);
+        assertParseFailure(parser, invalidKeyword, Period.MESSAGE_CONSTRAINTS_DATE_KEYWORDS);
 
         // One valid and one invalid keyword
         String invalidTestInput = " " + PREFIX_SHN_PERIOD_START + "2000-01-01 2000/01/01";
-        assertParseFailure(parser, invalidTestInput, Period.MESSAGE_CONSTRAINTS_DATE);
+        assertParseFailure(parser, invalidTestInput, Period.MESSAGE_CONSTRAINTS_DATE_KEYWORDS);
     }
 
     @Test
-    public void parse_validShnPeriodEndArgs_returnsFindCommand() {
+    public void parse_validShnPeriodEndArgs_success() {
         // no leading and trailing whitespaces after prefix
         FindCommand expectedFindCommand =
                 new FindCommand(new ShnPeriodEndEqualsKeywordsPredicate(Arrays.asList("2000-01-01",
@@ -149,13 +173,13 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_invalidShnPeriodEndArgs_returnsFindCommand() {
+    public void parse_invalidShnPeriodEndArgs_throwsParseException() {
         // One invalid keyword
         String invalidKeyword = " " + PREFIX_SHN_PERIOD_END + "2000/01/02";
-        assertParseFailure(parser, invalidKeyword, Period.MESSAGE_CONSTRAINTS_DATE);
+        assertParseFailure(parser, invalidKeyword, Period.MESSAGE_CONSTRAINTS_DATE_KEYWORDS);
 
         // One valid and one invalid keyword
         String invalidTestInput = " " + PREFIX_SHN_PERIOD_END + "2000-01-02 2000/01/02";
-        assertParseFailure(parser, invalidTestInput, Period.MESSAGE_CONSTRAINTS_DATE);
+        assertParseFailure(parser, invalidTestInput, Period.MESSAGE_CONSTRAINTS_DATE_KEYWORDS);
     }
 }


### PR DESCRIPTION
- Fixed minor error in `MESSAGE_CONSTRAINTS` of `phone` and updated `PHONE_NUMBER` and `NEXT_OF_KIN_PHONE` in UG
- Created a new field called `MESSAGE_CONSTRAINTS_KEYWORD` for fields used in `FindCommand`
- Updated `FindCommandParserTest` to test invalid `Phone` and `CaseNumber` keywords.