### PR TITLE
Fix EditCommand Result, UG and DG bugs

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -538,11 +538,11 @@ testers are expected to do more *exploratory* testing.
 
 1. Adding a person
 
-   1. Test case: `add n/John Doe p/91234567 e/johndoe@gmail.com cn/1 ha/123 Waterloo`<br>
+   1. Test case: `add n/John Doe p/91234567 e/johndoe@gmail.com cn/7 ha/123 Waterloo`<br>
        Expected: New person is added with the given details. Details of the added person shown in the
        status message.
 
-   2. Test case: `add n/John Doe p/91234567 e/johndoe@gmail.com cn/3 ha/123 Waterloo wa/456 Waterloo`<br>
+   2. Test case: `add n/Jane Doe p/98765432 e/janedoe@gmail.com cn/8 ha/123 Toronto wa/456 Toronto qa/789 Toronto sh/2000-01-01 2000-02-02 kn/Mary Jane kp/12345678 ka/555 Montreal`<br>
        Expected: New person is added with the given details. Details of the added person shown in the 
        status message.
 
@@ -568,12 +568,12 @@ testers are expected to do more *exploratory* testing.
    1. Prerequisites: List all persons using the `list` command. Multiple persons in the list.
 
    2. Test case: `edit 1 n/John Doe`<br>
-      Expected: First person in the list has their name edited to `John Doe`. Details of the edited person shown in the
+      Expected: First person in the list has their name edited to `John Doe`. Details of the edited field(s) are shown in the
       status message.
 
    3. Test case: `edit 1 n/John Doe cn/12`<br>
       Expected: First person in the list has their name edited to `John Doe` and their case number edited to `12`.
-      Details of the edited person shown in the status message.
+      Details of the edited field(s) are shown in the status message.
 
    4. Test case: `edit 1`<br>
       Expected: No persons' contact details will be edited. Error details shown in the status message. Status bar
@@ -589,7 +589,7 @@ testers are expected to do more *exploratory* testing.
 
 2. Editing a person while search results are being shown
 
-    Expected: Similar to previous, but person(s) are deleted based on their index(s) in the search results instead of the list.
+    Expected: Similar to previous, but person(s) are edited based on their index(s) in the search results instead of the list.
 
 ### Deleting a person
 
@@ -766,7 +766,7 @@ testers are expected to do more *exploratory* testing.
 ### Saving data
 
 1. Dealing with missing/corrupted data files
-    1. Test case: Empty JSON file.  
+    1. Test case: Missing JSON file.  
        Expected: Sample Track2Gather person list will be generated with sample persons' information.
     2. Test case: Corrupted JSON file.  
-       Expected: Sample Track2Gather person list will be generated with sample persons' information.
+       Expected: Empty Track2Gather person list will be generated.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -85,7 +85,7 @@ Refer to the [Features](#features) below for details of each command.
 
 Field | Format
 ------|------------------
-`NAME` | Names should only contain alphanumeric characters and spaces, and should not be blank.
+`NAME` | Names should only contain alphanumeric characters separated by spaces, and it should not be blank.
 `PHONE_NUMBER` | Phone numbers should be positive integers with no leading zeros, and should be 3 to 11 digits long.
 `EMAIL` | Emails should be of the format local-part@domain. <br> The local-part should only contain alphanumeric characters and these special characters: (+_.-), excluding the parentheses. The local-part may not start or end with any special characters. This is followed by a '@' and then a domain name. <br> The domain name is made up of domain labels separated by periods. The domain name must end with a domain label at least 2 characters long, have each domain label start and end with alphanumeric characters and must have each domain label consist of alphanumeric characters, separated only by hyphens, if any.
 `CASE_NUMBER` | Case numbers should be positive integers with no leading zeros, and should be between 1 to 6 digits long. Note that case numbers are displayed in a fixed format of 6 digits, padded with zeros on the left, if needed.
@@ -203,6 +203,7 @@ Format: `sort [n/DIRECTION] [cn/DIRECTION] [sh/start:DIRECTION] [sh/end:DIRECTIO
 * Direction `asc` indicates ascending sort order and `dsc` indicates descending sort order
 * Sorts the persons list from the first to the last specified field prefix
 * At least one field prefix must be provided
+* Letter case is ignored when sorting by name.
 * Specifying the sort direction is optional
   * By default, field prefixes are sorted in ascending order
 

--- a/src/main/java/seedu/track2gather/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/track2gather/logic/commands/EditCommand.java
@@ -63,7 +63,8 @@ public class EditCommand extends Command {
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Fields%1$s\n"
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited the following fields: \n"
+            + "%1$s\n"
             + MESSAGE_PREDICATE_SHOW_ALL_PERSONS;
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This case number already exists in the contacts list.";

--- a/src/main/java/seedu/track2gather/model/person/attributes/Name.java
+++ b/src/main/java/seedu/track2gather/model/person/attributes/Name.java
@@ -9,9 +9,9 @@ import static seedu.track2gather.commons.util.AppUtil.checkArgument;
 public class Name extends Attribute<String> implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters separated by spaces, and it should not be blank.";
     public static final String MESSAGE_CONSTRAINTS_KEYWORDS =
-            "Name keywords should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Name keywords should only contain alphanumeric characters separated by spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,


### PR DESCRIPTION
As discussed on Zoom, this PR will fix:  

1. Name format message.
2. Edited fields CommandResult.
3. Typo in DG for instructions for manual testing for `Add` and `Edit` command.
4. Fixed the behaviour of the app with corrupted JSON files in the DG.